### PR TITLE
Fixed the issue where HW decoder would crash in .cia

### DIFF
--- a/resource/app.rsf
+++ b/resource/app.rsf
@@ -26,7 +26,7 @@ AccessControlInfo:
   
   # Minimum Required Kernel Version (below is for 4.5.0)
   ReleaseKernelMajor            : "02"
-  ReleaseKernelMinor            : "33" 
+  ReleaseKernelMinor            : "44"
 
   # ExtData
   UseExtSaveData                : false # enables ExtData       


### PR DESCRIPTION
I read [this document](https://github.com/devkitPro/3ds-examples/tree/master/mvd), and it said "The process you run this under must also have kernel-release-version >=2.44(FIRM v8.0) in the exheader, such as System Settings".
I don't understand that sentence in detail, but raising the kernel release version to 2.44 solved the problem.
